### PR TITLE
Builds without bintray

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     // Integration tests
     testImplementation(group: 'org.testfx', name: 'openjfx-monocle', version: "jdk-12.0.1+2")
-    integrationTestImplementation(group: 'org.testcontainers', name: 'kafka', version: "1.14.3")
+    integrationTestImplementation(group: 'org.testcontainers', name: 'kafka', version: "1.15.1")
     integrationTestImplementation(group: 'org.apache.kafka', name: 'kafka-clients', version: '6.0.0-ce')
 }
 

--- a/buildSrc/src/main/groovy/insulator.base.gradle
+++ b/buildSrc/src/main/groovy/insulator.base.gradle
@@ -4,12 +4,9 @@ plugins{
 }
 
 repositories {
-    jcenter()
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
     maven { url "https://packages.confluent.io/maven/" }
-    maven { url "https://kotlin.bintray.com/kotlinx/" }
     maven { url "https://repository.mulesoft.org/nexus/content/repositories/public/" }
 }
 

--- a/lib/kafka/build.gradle
+++ b/lib/kafka/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     implementation(group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core-jvm', version: '1.4.1')
 
     // Test Container
-    api(group: 'org.testcontainers', name: 'kafka', version: "1.14.3")
+    api(group: 'org.testcontainers', name: 'kafka', version: "1.15.1")
 }

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -14,7 +14,7 @@ footer = """</files>
 </configuration>"""
 
 manual_dependencies = {
-    "kotlinx-serialization-runtime-jvm-1.0-M1-1.4.0-rc-218.jar": '<file uri="https://jcenter.bintray.com/org/jetbrains/kotlinx/kotlinx-serialization-runtime-jvm/1.0-M1-1.4.0-rc-218/kotlinx-serialization-runtime-jvm-1.0-M1-1.4.0-rc-218.jar" size="531216" classpath="true" checksum="222f5a14"/>',
+    # "kotlinx-serialization-runtime-jvm-1.0-M1-1.4.0-rc-218.jar": '<file uri="https://jcenter.bintray.com/org/jetbrains/kotlinx/kotlinx-serialization-runtime-jvm/1.0-M1-1.4.0-rc-218/kotlinx-serialization-runtime-jvm-1.0-M1-1.4.0-rc-218.jar" size="531216" classpath="true" checksum="222f5a14"/>',
     # javafx for mac
     "javafx-swing-15.0.1-mac.jar": '<file os="mac" uri="https://repo1.maven.org/maven2/org/openjfx/javafx-swing/15.0.1/javafx-swing-15.0.1-mac.jar" size="88725" classpath="true" checksum="f761e2bf"/>',
     "javafx-graphics-15.0.1-mac.jar": '<file os="mac" uri="https://repo1.maven.org/maven2/org/openjfx/javafx-graphics/15.0.1/javafx-graphics-15.0.1-mac.jar" size="4962652" classpath="true" checksum="6511c8ad"/>',


### PR DESCRIPTION
Fix for #175 
I assume libs have been moved to maven central.
I am not sure how the update4j stuff is supposed to work - there's a hard-coded link to a bintray file "kotlinx-serialization-runtime-jvm-1.0-M1-1.4.0-rc-218.jar" in constants.py, I guess will probably need to find the maven central equivalent?